### PR TITLE
Fix test suite instability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![travis](https://travis-ci.org/Tradeshift/io.svg?branch=master)](https://travis-ci.org/Tradeshift/io) [![npm](https://img.shields.io/npm/v/@tradeshift/io.svg)](https://npmjs.org/package/@tradeshift/io) [![Greenkeeper badge](https://badges.greenkeeper.io/Tradeshift/io.svg)](https://greenkeeper.io/)
+![travis](https://travis-ci.org/Tradeshift/io.svg?branch=master)](https://travis-ci.org/Tradeshift/io) [![npm](https://img.shields.io/npm/v/@tradeshift/io.svg)](https://npmjs.org/package/@tradeshift/io) [![Greenkeeper badge](https://badges.greenkeeper.io/Tradeshift/io.svg)](https://greenkeeper.io/)
 
 # `ts.io`
 
@@ -191,7 +191,7 @@ const hub = io({
 });
 
 // Terminate App Instance in target Window
-hub.forgetApp(win);
+hub.forgetApp(app, win);
 
 // Create App (a client) for the Tradeshift® Chrome™ and connect to Hub (The Broker)
 const top = hub.top();

--- a/test/lib/hub-mock.js
+++ b/test/lib/hub-mock.js
@@ -62,9 +62,7 @@ export const killAllApps = () => {
 		}
 		if (frame) {
 			try {
-				if (frame.contentWindow) {
-					hub.forgetApp(frame.contentWindow);
-				}
+				hub.forgetApp(app, frame.contentWindow);
 			} catch (e) {
 				console.log(
 					'[killAllApps] frame.contentWindow OR hub.forgetApp failed.\n' +

--- a/test/spec/hub.spec.js
+++ b/test/spec/hub.spec.js
@@ -1,11 +1,6 @@
 import { verifyTestMessage, removeAppOrFail } from '../lib/helpers';
 
 export default ({ apps, hub }) => {
-	const waitForTimeout = () =>
-		new Promise(resolve => {
-			hub._fakeTimeout = resolve;
-		});
-
 	describe('hub', () => {
 		let onMessage;
 		const eventListener = evt => {
@@ -50,15 +45,17 @@ export default ({ apps, hub }) => {
 				}
 			}
 
-			for (let i = 0; i < 4; i++) {
-				const app = await waitForTimeout();
+			hub._fakeTimeout = app => {
 				removeAppOrFail(
 					app,
 					apps,
 					'App timeout() called more than once for the same app!'
 				);
-			}
-			done();
+
+				if (!apps.length) {
+					done();
+				}
+			};
 		}, 5000);
 	});
 };


### PR DESCRIPTION
IE fails w/ permissionError when trying to use a removed iframe as a key
during cleanup. When cleanup fails, timeouts are not cleared, and the tests fail.

This commit introduces an appId to token map, that allows cleanup to
happen regardless of window state / cross origin issues.